### PR TITLE
Relax uuid constraint to support 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 0.4.1
+
+* Support uuid 4.0.0
+
 ### 0.4.0
 
 * Use Gradle 8.x - you need to use Gradle 8.x, as well as Gradle wrapper 8.x and upgrade your kotlin-gradle-plugin to 1.9.10

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: android_content_provider
 description: Flutter plugin to use ContentProvider/ContentResolver APIs on Android
-version: 0.4.0
+version: 0.4.1
 homepage: https://github.com/nt4f04uNd/android_content_provider/
 
 environment:
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   async: ^2.8.2
-  uuid: ^3.0.5
+  uuid: ">=3.0.5 <5.0.0"
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This relaxes the uuid constraint from `^3.0.5` to `">=3.0.5 <5.0.0"` so that constraint solving will work when an app uses a mix of plugins which depend on uuid 3 and uuid 4.

In my case, the audio_service example depends on audio_service_mpris which depends on uuid 4, and the example also depends on android_content_provider which depends on uuid 3, but does not permit uuid 4. Since android_content_provider's use of uuid is compatible with both versions of the uuid package, this should be safe (it is also the approach used in just_audio).