### PR TITLE
fix build errors in AndroidContentProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 0.4.2
+
+* Fix build issue with Flutter 3.24.0.
+
 ### 0.4.1
 
 * Support uuid 4.0.0

--- a/android/src/main/kotlin/com/nt4f04und/android_content_provider/AndroidContentProvider.kt
+++ b/android/src/main/kotlin/com/nt4f04und/android_content_provider/AndroidContentProvider.kt
@@ -37,9 +37,10 @@ import java.lang.Exception
  * Once the content provider is created, it is not destroyed, until the app process is.
  */
 abstract class AndroidContentProvider : ContentProvider(), LifecycleOwner, Utils {
-    override val lifecycle: Lifecycle by lazy { 
+    val lifecycleRegistry: LifecycleRegistry by lazy {
         LifecycleRegistry(this)
     }
+    override val lifecycle get() = lifecycleRegistry
     private lateinit var engine: FlutterEngine
     private lateinit var methodChannel: SynchronousMethodChannel
     private lateinit var trackingMapFactory: TrackingMapFactory
@@ -98,6 +99,7 @@ abstract class AndroidContentProvider : ContentProvider(), LifecycleOwner, Utils
         flutterLoader.startInitialization(context!!.applicationContext)
         val entrypoint = DartExecutor.DartEntrypoint(flutterLoader.findAppBundlePath(), entrypointName)
         val engineGroup = getFlutterEngineGroup(context!!)
+        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
         engine = engineGroup.createAndRunEngine(context!!, entrypoint)
         engine.contentProviderControlSurface.attachToContentProvider(this, lifecycle!!)
         trackingMapFactory = TrackingMapFactory(engine.dartExecutor.binaryMessenger)

--- a/android/src/main/kotlin/com/nt4f04und/android_content_provider/AndroidContentProvider.kt
+++ b/android/src/main/kotlin/com/nt4f04und/android_content_provider/AndroidContentProvider.kt
@@ -37,7 +37,9 @@ import java.lang.Exception
  * Once the content provider is created, it is not destroyed, until the app process is.
  */
 abstract class AndroidContentProvider : ContentProvider(), LifecycleOwner, Utils {
-    private var lifecycle: LifecycleRegistry? = null
+    override val lifecycle: Lifecycle by lazy { 
+        LifecycleRegistry(this)
+    }
     private lateinit var engine: FlutterEngine
     private lateinit var methodChannel: SynchronousMethodChannel
     private lateinit var trackingMapFactory: TrackingMapFactory
@@ -90,17 +92,6 @@ abstract class AndroidContentProvider : ContentProvider(), LifecycleOwner, Utils
      */
     abstract val entrypointName: String // TODO: eventually replace it with initialArguments
 
-    override fun getLifecycle(): Lifecycle {
-        ensureLifecycleInitialized()
-        return lifecycle!!
-    }
-
-    private fun ensureLifecycleInitialized() {
-        if (lifecycle == null) {
-            lifecycle = LifecycleRegistry(this)
-        }
-    }
-
     @CallSuper
     override fun onCreate(): Boolean {
         val flutterLoader = FlutterInjector.instance().flutterLoader()
@@ -108,8 +99,6 @@ abstract class AndroidContentProvider : ContentProvider(), LifecycleOwner, Utils
         val entrypoint = DartExecutor.DartEntrypoint(flutterLoader.findAppBundlePath(), entrypointName)
         val engineGroup = getFlutterEngineGroup(context!!)
         engine = engineGroup.createAndRunEngine(context!!, entrypoint)
-        ensureLifecycleInitialized()
-        lifecycle!!.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
         engine.contentProviderControlSurface.attachToContentProvider(this, lifecycle!!)
         trackingMapFactory = TrackingMapFactory(engine.dartExecutor.binaryMessenger)
         methodChannel = SynchronousMethodChannel(MethodChannel(

--- a/android/src/main/kotlin/com/nt4f04und/android_content_provider/AndroidContentProvider.kt
+++ b/android/src/main/kotlin/com/nt4f04und/android_content_provider/AndroidContentProvider.kt
@@ -37,10 +37,10 @@ import java.lang.Exception
  * Once the content provider is created, it is not destroyed, until the app process is.
  */
 abstract class AndroidContentProvider : ContentProvider(), LifecycleOwner, Utils {
-    val lifecycleRegistry: LifecycleRegistry by lazy {
+    override val lifecycle get() = lifecycleRegistry
+    private val lifecycleRegistry: LifecycleRegistry by lazy {
         LifecycleRegistry(this)
     }
-    override val lifecycle get() = lifecycleRegistry
     private lateinit var engine: FlutterEngine
     private lateinit var methodChannel: SynchronousMethodChannel
     private lateinit var trackingMapFactory: TrackingMapFactory

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: android_content_provider
 description: Flutter plugin to use ContentProvider/ContentResolver APIs on Android
-version: 0.4.1
+version: 0.4.2
 homepage: https://github.com/nt4f04uNd/android_content_provider/
 
 environment:


### PR DESCRIPTION
This fixes the build errors and the content provider runs. I'm not sure if I'm handling the lifecycle events correctly though. I just removed the `handleLifecycleEvent` because that doesn't seem to exist in the API now. 