### PR TITLE
Support Flutter 3.29.0+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,4 @@ GeneratedPluginRegistrant.*
 !default.perspectivev3
 
 .fvm
+.cxx

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 0.5.0
+
+* Support Flutter 3.29.0+
+  * Migrate to declarative Gradle https://docs.flutter.dev/release/breaking-changes/flutter-gradle-plugin-apply
+* **Breaking change**: change Flutter constraint to '>=3.16.0', because Kotlin DSL support was added starting from this version
+
 ### 0.4.3
 
 * Fixed compatibility with all Flutter versions (both below and above 3.24.0) via build script automation. Previous release was incompatible with Flutter versions below 3.24.0.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,18 +1,10 @@
+plugins {
+    id "com.android.library"
+    id "kotlin-android"
+}
+
 group 'com.nt4f04und.android_content_provider'
 version '1.0-SNAPSHOT'
-
-buildscript {
-    ext.kotlin_version = '1.9.10'
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.1'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
 
 rootProject.allprojects {
     repositories {
@@ -20,9 +12,6 @@ rootProject.allprojects {
         mavenCentral()
     }
 }
-
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
 
 android {
     // Conditional for compatibility with AGP <4.2.
@@ -58,7 +47,6 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "androidx.core:core-ktx:1.7.0"
 }
 

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -1,14 +1,15 @@
+plugins {
+    id "com.android.application"
+    id "kotlin-android"
+    id "dev.flutter.flutter-gradle-plugin"
+}
+
 def localProperties = new Properties()
 def localPropertiesFile = rootProject.file('local.properties')
 if (localPropertiesFile.exists()) {
     localPropertiesFile.withReader('UTF-8') { reader ->
         localProperties.load(reader)
     }
-}
-
-def flutterRoot = localProperties.getProperty('flutter.sdk')
-if (flutterRoot == null) {
-    throw new GradleException("Flutter SDK not found. Define location with flutter.sdk in the local.properties file.")
 }
 
 def flutterVersionCode = localProperties.getProperty('flutter.versionCode')
@@ -20,10 +21,6 @@ def flutterVersionName = localProperties.getProperty('flutter.versionName')
 if (flutterVersionName == null) {
     flutterVersionName = '1.0'
 }
-
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
-apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
     // Conditional for compatibility with AGP <4.2.
@@ -67,7 +64,6 @@ flutter {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     androidTestImplementation 'androidx.test:runner:1.4.0'
     androidTestImplementation 'androidx.test:rules:1.4.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,16 +1,3 @@
-buildscript {
-    ext.kotlin_version = '1.9.10'
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.1'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-
 allprojects {
     repositories {
         google()

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -1,11 +1,25 @@
-include ':app'
+pluginManagement {
+    def flutterSdkPath = {
+        def properties = new Properties()
+        file("local.properties").withInputStream { properties.load(it) }
+        def flutterSdkPath = properties.getProperty("flutter.sdk")
+        assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
+        return flutterSdkPath
+    }()
 
-def localPropertiesFile = new File(rootProject.projectDir, "local.properties")
-def properties = new Properties()
+    includeBuild("$flutterSdkPath/packages/flutter_tools/gradle")
 
-assert localPropertiesFile.exists()
-localPropertiesFile.withReader("UTF-8") { reader -> properties.load(reader) }
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
 
-def flutterSdkPath = properties.getProperty("flutter.sdk")
-assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
-apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"
+plugins {
+    id "dev.flutter.flutter-plugin-loader" version "1.0.0"
+    id "com.android.application" version "8.1.1" apply false
+    id "org.jetbrains.kotlin.android" version "1.9.10" apply false
+}
+
+include ":app"

--- a/example/lib/books_page.dart
+++ b/example/lib/books_page.dart
@@ -2,6 +2,7 @@
 /// This example shows off and interaction with [AndroidContentProvider],
 /// defined by `example_provider` app.
 ///
+library;
 
 import 'package:android_content_provider/android_content_provider.dart';
 import 'package:flutter/material.dart';
@@ -10,7 +11,7 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 class BooksPage extends HookConsumerWidget {
-  const BooksPage({Key? key}) : super(key: key);
+  const BooksPage({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -22,7 +23,9 @@ class BooksPage extends HookConsumerWidget {
     final textEditingController = useTextEditingController();
 
     useEffect(() {
-      bookDataManager.query();
+      WidgetsBinding.instance.addPostFrameCallback((timestamp) {
+        bookDataManager.query();
+      });
       return null;
     }, const []);
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -10,7 +10,7 @@ void main() async {
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
+  const MyApp({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/example/lib/media_store_songs_page.dart
+++ b/example/lib/media_store_songs_page.dart
@@ -1,6 +1,7 @@
 ///
 /// This example shows off fetching songs from MediaStore with [AndroidContentResolver].
 ///
+library;
 
 import 'package:android_content_provider/android_content_provider.dart';
 import 'package:flutter/material.dart';
@@ -9,7 +10,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:permission_handler/permission_handler.dart';
 
 class MediaStoreSongsPage extends HookConsumerWidget {
-  const MediaStoreSongsPage({Key? key}) : super(key: key);
+  const MediaStoreSongsPage({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -3,16 +3,17 @@ description: Demonstrates how to use the android_content_provider plugin.
 publish_to: 'none'
 
 environment:
-  sdk: ">=2.15.0 <4.0.0"
+  sdk: '>=3.0.0 <4.0.0'
+  flutter: '>=3.16.0'
 
 dependencies:
   flutter:
     sdk: flutter
-  riverpod: ^2.4.0
-  flutter_riverpod: ^2.4.0
-  hooks_riverpod: ^2.4.0
+  riverpod: ^2.6.1
+  flutter_riverpod: ^2.6.1
+  hooks_riverpod: ^2.6.1
   flutter_hooks: ^0.20.1
-  permission_handler: ^10.4.3
+  permission_handler: ^11.3.1
 
   android_content_provider:
     path: ../
@@ -20,7 +21,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^2.0.3
+  flutter_lints: ^3.0.1
 
 flutter:
   uses-material-design: true

--- a/example_provider/android/app/build.gradle
+++ b/example_provider/android/app/build.gradle
@@ -1,14 +1,15 @@
+plugins {
+    id "com.android.application"
+    id "kotlin-android"
+    id "dev.flutter.flutter-gradle-plugin"
+}
+
 def localProperties = new Properties()
 def localPropertiesFile = rootProject.file('local.properties')
 if (localPropertiesFile.exists()) {
     localPropertiesFile.withReader('UTF-8') { reader ->
         localProperties.load(reader)
     }
-}
-
-def flutterRoot = localProperties.getProperty('flutter.sdk')
-if (flutterRoot == null) {
-    throw new GradleException("Flutter SDK not found. Define location with flutter.sdk in the local.properties file.")
 }
 
 def flutterVersionCode = localProperties.getProperty('flutter.versionCode')
@@ -20,10 +21,6 @@ def flutterVersionName = localProperties.getProperty('flutter.versionName')
 if (flutterVersionName == null) {
     flutterVersionName = '1.0'
 }
-
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
-apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
     // Conditional for compatibility with AGP <4.2.
@@ -67,7 +64,6 @@ flutter {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     androidTestImplementation 'androidx.test:runner:1.4.0'
     androidTestImplementation 'androidx.test:rules:1.4.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/example_provider/android/build.gradle
+++ b/example_provider/android/build.gradle
@@ -1,16 +1,3 @@
-buildscript {
-    ext.kotlin_version = '1.9.10'
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.1'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-
 allprojects {
     repositories {
         google()

--- a/example_provider/android/settings.gradle
+++ b/example_provider/android/settings.gradle
@@ -1,11 +1,25 @@
-include ':app'
+pluginManagement {
+    def flutterSdkPath = {
+        def properties = new Properties()
+        file("local.properties").withInputStream { properties.load(it) }
+        def flutterSdkPath = properties.getProperty("flutter.sdk")
+        assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
+        return flutterSdkPath
+    }()
 
-def localPropertiesFile = new File(rootProject.projectDir, "local.properties")
-def properties = new Properties()
+    includeBuild("$flutterSdkPath/packages/flutter_tools/gradle")
 
-assert localPropertiesFile.exists()
-localPropertiesFile.withReader("UTF-8") { reader -> properties.load(reader) }
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
 
-def flutterSdkPath = properties.getProperty("flutter.sdk")
-assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
-apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"
+plugins {
+    id "dev.flutter.flutter-plugin-loader" version "1.0.0"
+    id "com.android.application" version "8.1.1" apply false
+    id "org.jetbrains.kotlin.android" version "1.9.10" apply false
+}
+
+include ":app"

--- a/example_provider/lib/main.dart
+++ b/example_provider/lib/main.dart
@@ -3,6 +3,7 @@
 ///
 /// To see an example of AndroidContentResolver, check out the `example` app.
 ///
+library;
 
 import 'dart:async';
 
@@ -16,7 +17,7 @@ void main() async {
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
+  const MyApp({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -74,7 +75,7 @@ const baseUri =
 const booksUri = '$baseUri/books';
 
 class MyAndroidContentProvider extends AndroidContentProvider {
-  MyAndroidContentProvider(String authority) : super(authority);
+  MyAndroidContentProvider(super.authority);
 
   final _booksDataList = List.generate(
     10,

--- a/example_provider/pubspec.yaml
+++ b/example_provider/pubspec.yaml
@@ -3,7 +3,8 @@ description: Demonstrates how to use the android_content_provider plugin.
 publish_to: 'none'
 
 environment:
-  sdk: ">=2.15.0 <4.0.0"
+  sdk: '>=3.0.0 <4.0.0'
+  flutter: '>=3.16.0'
 
 dependencies:
   flutter:
@@ -12,10 +13,12 @@ dependencies:
   android_content_provider:
     path: ../
 
+  collection: any
+
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^2.0.3
+  flutter_lints: ^3.0.1
 
 flutter:
   uses-material-design: true

--- a/integration_test/android/app/build.gradle
+++ b/integration_test/android/app/build.gradle
@@ -1,14 +1,15 @@
+plugins {
+    id "com.android.application"
+    id "kotlin-android"
+    id "dev.flutter.flutter-gradle-plugin"
+}
+
 def localProperties = new Properties()
 def localPropertiesFile = rootProject.file('local.properties')
 if (localPropertiesFile.exists()) {
     localPropertiesFile.withReader('UTF-8') { reader ->
         localProperties.load(reader)
     }
-}
-
-def flutterRoot = localProperties.getProperty('flutter.sdk')
-if (flutterRoot == null) {
-    throw new GradleException("Flutter SDK not found. Define location with flutter.sdk in the local.properties file.")
 }
 
 def flutterVersionCode = localProperties.getProperty('flutter.versionCode')
@@ -20,10 +21,6 @@ def flutterVersionName = localProperties.getProperty('flutter.versionName')
 if (flutterVersionName == null) {
     flutterVersionName = '1.0'
 }
-
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
-apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
     // Conditional for compatibility with AGP <4.2.
@@ -66,8 +63,4 @@ android {
 
 flutter {
     source '../..'
-}
-
-dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }

--- a/integration_test/android/build.gradle
+++ b/integration_test/android/build.gradle
@@ -1,16 +1,3 @@
-buildscript {
-    ext.kotlin_version = '1.9.10'
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.1'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-
 allprojects {
     repositories {
         google()

--- a/integration_test/android/settings.gradle
+++ b/integration_test/android/settings.gradle
@@ -1,11 +1,25 @@
-include ':app'
+pluginManagement {
+    def flutterSdkPath = {
+        def properties = new Properties()
+        file("local.properties").withInputStream { properties.load(it) }
+        def flutterSdkPath = properties.getProperty("flutter.sdk")
+        assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
+        return flutterSdkPath
+    }()
 
-def localPropertiesFile = new File(rootProject.projectDir, "local.properties")
-def properties = new Properties()
+    includeBuild("$flutterSdkPath/packages/flutter_tools/gradle")
 
-assert localPropertiesFile.exists()
-localPropertiesFile.withReader("UTF-8") { reader -> properties.load(reader) }
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
 
-def flutterSdkPath = properties.getProperty("flutter.sdk")
-assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
-apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"
+plugins {
+    id "dev.flutter.flutter-plugin-loader" version "1.0.0"
+    id "com.android.application" version "8.1.1" apply false
+    id "org.jetbrains.kotlin.android" version "1.9.10" apply false
+}
+
+include ":app"

--- a/integration_test/lib/main.dart
+++ b/integration_test/lib/main.dart
@@ -85,14 +85,14 @@ const authority =
 const providerUri = 'content://$authority';
 
 const overflowingContentValuesTest =
-    providerUri + '/overflowingContentValuesTest';
-const deleteWithExtrasTest = providerUri + '/deleteWithExtrasTest';
-const insertWithExtrasTest = providerUri + '/insertWithExtrasTest';
-const queryWithExtrasTest = providerUri + '/queryWithExtrasTest';
-const updateWithExtrasTest = providerUri + '/updateWithExtrasTest';
+    '$providerUri/overflowingContentValuesTest';
+const deleteWithExtrasTest = '$providerUri/deleteWithExtrasTest';
+const insertWithExtrasTest = '$providerUri/insertWithExtrasTest';
+const queryWithExtrasTest = '$providerUri/queryWithExtrasTest';
+const updateWithExtrasTest = '$providerUri/updateWithExtrasTest';
 const queryCursorInvalidNotificationUriTest =
-    providerUri + '/queryCursorInvalidNotificationUriTest';
-const nullableCursorTest = providerUri + '/nullableCursorTest';
+    '$providerUri/queryCursorInvalidNotificationUriTest';
+const nullableCursorTest = '$providerUri/nullableCursorTest';
 
 final throwsSecurityException = throwsA(isA<PlatformException>().having(
   (e) => e.details,
@@ -252,7 +252,7 @@ Future<void> main() async {
             expect(selfChange, false);
             expect(uris, [
               notifyForDescendantsTest
-                  ? providerUri + '/descendantUriShouldNotify'
+                  ? '$providerUri/descendantUriShouldNotify'
                   : providerUri
             ]);
             expect(flags, flags);
@@ -291,7 +291,7 @@ Future<void> main() async {
           flags: flags,
         );
         await AndroidContentResolver.instance.notifyChangeWithList(
-          uris: [providerUri + '/descendantUriShouldNotNotify'],
+          uris: ['$providerUri/descendantUriShouldNotNotify'],
           flags: flags,
         );
       } finally {
@@ -314,7 +314,7 @@ Future<void> main() async {
       );
       try {
         await AndroidContentResolver.instance.notifyChangeWithList(
-          uris: [providerUri + '/descendantUriShouldNotify'],
+          uris: ['$providerUri/descendantUriShouldNotify'],
           flags: flags,
         );
       } finally {
@@ -454,7 +454,7 @@ Future<void> main() async {
           throwsSecurityException,
         );
 
-        const newNotificationUri = providerUri + '/uri';
+        const newNotificationUri = '$providerUri/uri';
         await cursor.setNotificationUri(newNotificationUri);
         expect(await cursor.getNotificationUri(), newNotificationUri);
         expect(await cursor.getNotificationUris(), [newNotificationUri]);

--- a/integration_test/pubspec.yaml
+++ b/integration_test/pubspec.yaml
@@ -3,7 +3,8 @@ description: Integration test for the android_content_provider plugin.
 publish_to: 'none'
 
 environment:
-  sdk: ">=2.15.0 <4.0.0"
+  sdk: '>=3.0.0 <4.0.0'
+  flutter: '>=3.16.0'
 
 dependencies:
   flutter:
@@ -17,7 +18,7 @@ dependencies:
     path: ../
 
 dev_dependencies:
-  flutter_lints: ^2.0.3
+  flutter_lints: ^3.0.1
 
 flutter:
   uses-material-design: true

--- a/lib/android_content_provider.dart
+++ b/lib/android_content_provider.dart
@@ -1,7 +1,7 @@
 /// This library exposes ContentProvider and related ContentResolver APIs on Android.
 ///
 /// Read more in the [README](https://github.com/nt4f04uNd/android_content_provider).
-library android_content_provider;
+library;
 
 import 'dart:convert';
 import 'dart:async';

--- a/lib/src/android_content_provider.dart
+++ b/lib/src/android_content_provider.dart
@@ -1,4 +1,4 @@
-part of android_content_provider;
+part of '../android_content_provider.dart';
 
 /// A communication interface with native Android ContentProvider
 /// https://developer.android.com/reference/android/content/ContentProvider
@@ -238,7 +238,7 @@ abstract class AndroidContentProvider {
   //
   //
 
-  /// bulkInsert(uri: Uri, values: Array<ContentValues!>): Int
+  /// `bulkInsert(uri: Uri, values: Array<ContentValues!>): Int`
   /// https://developer.android.com/reference/kotlin/android/content/ContentProvider#bulkinsert
   Future<int> bulkInsert(String uri, List<ContentValues> values) async {
     for (final value in values) {
@@ -294,7 +294,7 @@ abstract class AndroidContentProvider {
     return result == null ? null : CallingIdentity.fromId(result);
   }
 
-  /// delete(uri: Uri, selection: String?, selectionArgs: Array<String!>?): Int
+  /// `delete(uri: Uri, selection: String?, selectionArgs: Array<String!>?): Int`
   /// https://developer.android.com/reference/kotlin/android/content/ContentProvider#delete
   Future<int> delete(
     String uri,
@@ -379,7 +379,7 @@ abstract class AndroidContentProvider {
   //
   //
 
-  /// getStreamTypes(uri: Uri, mimeTypeFilter: String): Array<String!>?
+  /// `getStreamTypes(uri: Uri, mimeTypeFilter: String): Array<String!>?`
   /// https://developer.android.com/reference/kotlin/android/content/ContentProvider#getstreamtypes
   Future<List<String>?> getStreamTypes(
     String uri,
@@ -476,7 +476,7 @@ abstract class AndroidContentProvider {
   // For example see https://android.googlesource.com/platform/development/+/4779ab6f9aa4d6b691f051e069ffac31475f850a/samples/NotePad/src/com/example/android/notepad/NotePadProvider.java
   //
 
-  /// query(uri: Uri, projection: Array<String!>?, selection: String?, selectionArgs: Array<String!>?, sortOrder: String?): Cursor?
+  /// `query(uri: Uri, projection: Array<String!>?, selection: String?, selectionArgs: Array<String!>?, sortOrder: String?): Cursor?`
   /// https://developer.android.com/reference/kotlin/android/content/ContentProvider#query
   Future<CursorData?> query(
     String uri,
@@ -486,7 +486,7 @@ abstract class AndroidContentProvider {
     String? sortOrder,
   );
 
-  /// query(uri: Uri, projection: Array<String!>?, selection: String?, selectionArgs: Array<String!>?, sortOrder: String?, cancellationSignal: CancellationSignal?): Cursor?
+  /// `query(uri: Uri, projection: Array<String!>?, selection: String?, selectionArgs: Array<String!>?, sortOrder: String?, cancellationSignal: CancellationSignal?): Cursor?`
   /// https://developer.android.com/reference/kotlin/android/content/ContentProvider#query_1
   Future<CursorData?> queryWithSignal(
     String uri,
@@ -499,7 +499,7 @@ abstract class AndroidContentProvider {
     return query(uri, projection, selection, selectionArgs, sortOrder);
   }
 
-  /// query(uri: Uri, projection: Array<String!>?, queryArgs: Bundle?, cancellationSignal: CancellationSignal?): Cursor?
+  /// `query(uri: Uri, projection: Array<String!>?, queryArgs: Bundle?, cancellationSignal: CancellationSignal?): Cursor?`
   /// https://developer.android.com/reference/kotlin/android/content/ContentProvider#query_2
   Future<CursorData?> queryWithExtras(
     String uri,
@@ -572,7 +572,7 @@ abstract class AndroidContentProvider {
     return url;
   }
 
-  /// update(uri: Uri, values: ContentValues?, selection: String?, selectionArgs: Array<String!>?): Int
+  /// `update(uri: Uri, values: ContentValues?, selection: String?, selectionArgs: Array<String!>?): Int`
   /// https://developer.android.com/reference/kotlin/android/content/ContentProvider#update
   Future<int> update(
     String uri,

--- a/lib/src/android_content_resolver.dart
+++ b/lib/src/android_content_resolver.dart
@@ -1,4 +1,4 @@
-part of android_content_provider;
+part of '../android_content_provider.dart';
 
 /// A communication interface with native Android ContentResolver
 /// https://developer.android.com/reference/android/content/ContentResolver
@@ -138,13 +138,13 @@ class AndroidContentResolver {
 
     String query = columns.join(', ');
 
-    const _collatorPrimary = 0;
-    const _collatorSecondary = 1;
+    const collatorPrimary = 0;
+    const collatorSecondary = 1;
 
     // Interpret PRIMARY and SECONDARY collation strength as no-case collation based
     // on their javadoc descriptions.
     final collation = queryArgs[QUERY_ARG_SORT_COLLATION] as int?;
-    if (collation == _collatorPrimary || collation == _collatorSecondary) {
+    if (collation == collatorPrimary || collation == collatorSecondary) {
       query += " COLLATE NOCASE";
     }
 
@@ -191,7 +191,7 @@ class AndroidContentResolver {
   //
   //
 
-  /// bulkInsert(uri: Uri, values: Array<ContentValues!>): Int
+  /// `bulkInsert(uri: Uri, values: Array<ContentValues!>): Int`
   /// https://developer.android.com/reference/kotlin/android/content/ContentResolver#bulkinsert
   Future<int> bulkInsert({
     required String uri,
@@ -246,7 +246,7 @@ class AndroidContentResolver {
     });
   }
 
-  /// delete(uri: Uri, arg: String?, selectionArgs: Array<String!>?): Int
+  /// `delete(uri: Uri, arg: String?, selectionArgs: Array<String!>?): Int`
   /// https://developer.android.com/reference/kotlin/android/content/ContentResolver#delete
   Future<int> delete({
     required String uri,
@@ -275,7 +275,7 @@ class AndroidContentResolver {
     return result!;
   }
 
-  /// getStreamTypes(uri: Uri, mimeTypeFilter: String): Array<String!>?
+  /// `getStreamTypes(uri: Uri, mimeTypeFilter: String): Array<String!>?`
   /// https://developer.android.com/reference/kotlin/android/content/ContentResolver#getstreamtypes
   Future<List<String>?> getStreamTypes({
     required String uri,
@@ -377,7 +377,7 @@ class AndroidContentResolver {
   //
   //
 
-  /// notifyChange(uris: MutableCollection<Uri!>, observer: ContentObserver?, flags: Int): Unit
+  /// `notifyChange(uris: MutableCollection<Uri!>, observer: ContentObserver?, flags: Int): Unit`
   /// https://developer.android.com/reference/kotlin/android/content/ContentResolver#notifychange_3
   @RequiresApiOrThrows(30)
   Future<void> notifyChangeWithList({
@@ -432,7 +432,7 @@ class AndroidContentResolver {
   //
   //
 
-  /// query(uri: Uri, projection: Array<String!>?, selection: String?, selectionArgs: Array<String!>?, sortOrder: String?): Cursor?
+  /// `query(uri: Uri, projection: Array<String!>?, selection: String?, selectionArgs: Array<String!>?, sortOrder: String?): Cursor?`
   /// https://developer.android.com/reference/kotlin/android/content/ContentResolver#query
   Future<NativeCursor?> query({
     required String uri,
@@ -451,7 +451,7 @@ class AndroidContentResolver {
     return result == null ? null : NativeCursor.fromId(result);
   }
 
-  /// query(uri: Uri, projection: Array<String!>?, selection: String?, selectionArgs: Array<String!>?, sortOrder: String?, cancellationSignal: CancellationSignal?): Cursor?
+  /// `query(uri: Uri, projection: Array<String!>?, selection: String?, selectionArgs: Array<String!>?, sortOrder: String?, cancellationSignal: CancellationSignal?): Cursor?`
   /// https://developer.android.com/reference/kotlin/android/content/ContentResolver#query_1
   Future<NativeCursor?> queryWithSignal({
     required String uri,
@@ -477,7 +477,7 @@ class AndroidContentResolver {
     }
   }
 
-  /// query(uri: Uri, projection: Array<String!>?, queryArgs: Bundle?, cancellationSignal: CancellationSignal?): Cursor?
+  /// `query(uri: Uri, projection: Array<String!>?, queryArgs: Bundle?, cancellationSignal: CancellationSignal?): Cursor?`
   /// https://developer.android.com/reference/kotlin/android/content/ContentResolver#query_2
   @RequiresApiOrThrows(26)
   Future<NativeCursor?> queryWithExtras({
@@ -551,7 +551,7 @@ class AndroidContentResolver {
     });
   }
 
-  /// update(uri: Uri, values: ContentValues?, arg: String?, selectionArgs: Array<String!>?): Int
+  /// `update(uri: Uri, values: ContentValues?, arg: String?, selectionArgs: Array<String!>?): Int`
   /// https://developer.android.com/reference/kotlin/android/content/ContentResolver#update
   Future<int> update({
     required String uri,

--- a/lib/src/annotation.dart
+++ b/lib/src/annotation.dart
@@ -1,4 +1,4 @@
-part of android_content_provider;
+part of '../android_content_provider.dart';
 
 /// Annotation on [AndroidContentProvider] methods.
 ///

--- a/lib/src/calling_identity.dart
+++ b/lib/src/calling_identity.dart
@@ -1,11 +1,11 @@
-part of android_content_provider;
+part of '../android_content_provider.dart';
 
 /// Opaque token representing the identity of an incoming IPC
 /// https://developer.android.com/reference/android/content/ContentProvider.CallingIdentity
 class CallingIdentity extends Interoperable {
   /// Creates calling identity from an existing ID.
   @visibleForTesting
-  CallingIdentity.fromId(String id) : super.fromId(id);
+  CallingIdentity.fromId(super.id) : super.fromId();
 
   @override
   String toString() {

--- a/lib/src/cancellation_signal.dart
+++ b/lib/src/cancellation_signal.dart
@@ -1,4 +1,4 @@
-part of android_content_provider;
+part of '../android_content_provider.dart';
 
 /// Provides the ability to cancel an operation in progress
 /// https://developer.android.com/reference/android/os/CancellationSignal

--- a/lib/src/codec.dart
+++ b/lib/src/codec.dart
@@ -1,4 +1,4 @@
-part of android_content_provider;
+part of '../android_content_provider.dart';
 
 List<T>? _asList<T>(Object? value) {
   return (value as List?)?.cast<T>();
@@ -17,7 +17,7 @@ class _NumberWrapper<T extends num> {
 
 /// A wrapper for value in [ContentValues.putByte].
 class _Byte extends _NumberWrapper<int> {
-  const _Byte(int value) : super(value);
+  const _Byte(super.value);
 
   @override
   String toString() {
@@ -27,7 +27,7 @@ class _Byte extends _NumberWrapper<int> {
 
 /// A wrapper for value in [ContentValues.putShort].
 class _Short extends _NumberWrapper<int> {
-  const _Short(int value) : super(value);
+  const _Short(super.value);
 
   @override
   String toString() {
@@ -41,7 +41,7 @@ class _Short extends _NumberWrapper<int> {
 
 /// A wrapper for value in [ContentValues.putLong].
 class _Long extends _NumberWrapper<int> {
-  const _Long(int value) : super(value);
+  const _Long(super.value);
 
   @override
   String toString() {
@@ -51,7 +51,7 @@ class _Long extends _NumberWrapper<int> {
 
 /// A wrapper for value in [ContentValues.putFloat].
 class _Float extends _NumberWrapper<double> {
-  const _Float(double value) : super(value);
+  const _Float(super.value);
 
   @override
   String toString() {

--- a/lib/src/content_observer.dart
+++ b/lib/src/content_observer.dart
@@ -1,4 +1,4 @@
-part of android_content_provider;
+part of '../android_content_provider.dart';
 
 /// Receives call backs for changes to content
 /// https://developer.android.com/reference/android/database/ContentObserver

--- a/lib/src/content_values.dart
+++ b/lib/src/content_values.dart
@@ -1,4 +1,4 @@
-part of android_content_provider;
+part of '../android_content_provider.dart';
 
 /// This class is used to store a set of values that the content provider/resolver can process
 /// https://developer.android.com/reference/android/content/ContentValues

--- a/lib/src/contract.dart
+++ b/lib/src/contract.dart
@@ -1,4 +1,4 @@
-part of android_content_provider;
+part of '../android_content_provider.dart';
 
 /// An object that can be associated with some native counterpart instance.
 ///

--- a/lib/src/core.dart
+++ b/lib/src/core.dart
@@ -1,4 +1,4 @@
-part of android_content_provider;
+part of '../android_content_provider.dart';
 
 const _uuid = Uuid();
 const _channelPrefix = 'com.nt4f04und.android_content_provider';

--- a/lib/src/cursor.dart
+++ b/lib/src/cursor.dart
@@ -1,4 +1,4 @@
-part of android_content_provider;
+part of '../android_content_provider.dart';
 
 /// The cursor that calls into platform Cursor
 /// https://developer.android.com/reference/android/database/Cursor
@@ -34,12 +34,12 @@ part of android_content_provider;
 class NativeCursor extends Interoperable {
   /// Creates native cursor from an existing ID.
   @visibleForTesting
-  NativeCursor.fromId(String id)
+  NativeCursor.fromId(super.id)
       : _methodChannel = MethodChannel(
           '$_channelPrefix/Cursor/$id',
           _pluginMethodCodec,
         ),
-        super.fromId(id);
+        super.fromId();
 
   /// Supported types in Android SQLite.
   ///
@@ -514,9 +514,8 @@ class MatrixCursorData extends CursorData {
   /// Creates the matrix cursor data.
   MatrixCursorData({
     required List<String> columnNames,
-    required List<String>? notificationUris,
-  })  : _columnNames = List.unmodifiable(columnNames),
-        super(notificationUris: notificationUris);
+    required super.notificationUris,
+  }) : _columnNames = List.unmodifiable(columnNames);
 
   /// All column names, given on cursor data creation.
   List<String> get columnNames => List.unmodifiable(_columnNames);
@@ -611,5 +610,5 @@ class MatrixCursorDataRowBuilder {
 /// https://developer.android.com/reference/android/database/CursorIndexOutOfBoundsException
 class CursorRangeError extends RangeError {
   /// Crerates cursor range error.
-  CursorRangeError(String message) : super(message);
+  CursorRangeError(String super.message);
 }

--- a/lib/src/mime_type_info.dart
+++ b/lib/src/mime_type_info.dart
@@ -1,4 +1,4 @@
-part of android_content_provider;
+part of '../android_content_provider.dart';
 
 /// Detailed description of a specific MIME type, including an icon and label that describe the type
 /// https://developer.android.com/reference/android/content/ContentResolver.MimeTypeInfo

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: android_content_provider
 description: Flutter plugin to use ContentProvider/ContentResolver APIs on Android
-version: 0.4.3
+version: 0.5.0
 homepage: https://github.com/nt4f04uNd/android_content_provider/
 
 environment:
-  sdk: ">=2.15.0 <4.0.0"
-  flutter: ">=2.8.0"
+  sdk: '>=3.0.0 <4.0.0'
+  flutter: '>=3.16.0'
 
 dependencies:
   flutter:
@@ -16,7 +16,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^2.0.3
+  flutter_lints: ^3.0.1
 
 flutter:
   plugin:


### PR DESCRIPTION
* Support Flutter 3.29.0+
  * Migrate to declarative Gradle https://docs.flutter.dev/release/breaking-changes/flutter-gradle-plugin-apply
* **Breaking change**: change Flutter constraint to '>=3.16.0', because Kotlin DSL support was added starting from this version
